### PR TITLE
Fix too many open files error in openstack dashboard

### DIFF
--- a/files/session.py.patch
+++ b/files/session.py.patch
@@ -1,0 +1,37 @@
+--- /usr/lib/python2.7/site-packages/keystoneauth1/session.py.orig	2018-09-05 10:15:46.959241934 +0000
++++ /usr/lib/python2.7/site-packages/keystoneauth1/session.py	2018-09-05 10:20:48.802856354 +0000
+@@ -58,7 +58,7 @@
+     # update the betamax fixture's '_construct_session_with_betamax" function
+     # as well.
+     if not session_obj:
+-        session_obj = requests.Session()
++        session_obj = _FakeRequestSession()
+         # Use TCPKeepAliveAdapter to fix bug 1323862
+         for scheme in list(session_obj.adapters):
+             session_obj.mount(scheme, TCPKeepAliveAdapter())
+@@ -184,6 +184,24 @@
+         name = _determine_calling_package()
+     return name
+ 
++class _FakeRequestSession(object):
++    """This object is a temporary hack that should be removed later.
++
++    Keystoneclient has a cyclical dependency with its managers which is
++    preventing it from being cleaned up correctly. This is always bad but when
++    we switched to doing connection pooling this object wasn't getting cleaned
++    either and so we had left over TCP connections hanging around.
++
++    Until we can fix the client cleanup we rollback the use of a requests
++    session and do individual connections like we used to.
++    """
++    def __init__(self):
++        self.adapters = []
++
++    def request(self, *args, **kwargs):
++        return requests.request(*args, **kwargs)
++
++
+ 
+ class Session(object):
+     """Maintains client communication state and common functionality.
+

--- a/patch-dashboad-open-files.yaml
+++ b/patch-dashboad-open-files.yaml
@@ -1,0 +1,10 @@
+- hosts: controller
+
+  tasks:
+    # fixes bug https://bugs.launchpad.net/horizon/+bug/1780164
+    - name: patch dashboard file descriptor leak
+      patch:
+        src: session.py.patch 
+        dest: /usr/lib/python2.7/site-packages/keystoneauth1/session.py
+        remote_src: no
+        backup: yes


### PR DESCRIPTION
The dashboard has a file desriptor leak when connecting to keystone
for authentication.  This eventually exceeds the softmax file handles
of 1024 and causes the openstack-dashboard process to stop responding
leading the an nginx bad gateway error when viewing the dashboard.

The bug is documented here https://bugs.launchpad.net/horizon/+bug/1780164
and has a comment with a patch.

This playbook applies the patch