### PR TITLE
Account util

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,21 @@ reach the updated dashboard configuration.
 ```
 ansible-playbook -i hosts proxy-services.yaml -K -b
 ```
+
+## New accounts
+
+Once the cluster is created you can create new accounts using the commandline tools and a CSV file.
+The file format is username,email,password, eg. users.csv.
+
+Make sure to have the openstack cli set up with an admin account on openstack. Then run the following:
+```
+for rec in `cat  users.csv`
+do
+  user=`echo $rec | cut -d, -f1`
+  email=`echo $rec | cut -d, -f2`
+  pass=`echo $rec | cut -d, -f3`
+  echo $user
+  ./os-create-user $user $email $pass
+done
+```
+

--- a/os-create-user
+++ b/os-create-user
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# create basic openstack accounts with a self-named project
+# user is member of project
+
+user=$1
+email=$2
+passwd=$3
+
+openstack project create $user
+openstack user create --project $user --email $email --password $passwd --enable $user
+openstack role add --project $user --user $user member

--- a/os-create-user
+++ b/os-create-user
@@ -6,7 +6,9 @@
 user=$1
 email=$2
 passwd=$3
+name=$4
+domain=$5
 
-openstack project create $user
-openstack user create --project $user --email $email --password $passwd --enable $user
-openstack role add --project $user --user $user member
+openstack project create $user --domain=$domain
+openstack user create --project $user --email $email --password $passwd --enable $user --domain=$domain --description="$name"
+openstack role add --project $user --user $user member --user-domain=$domain


### PR DESCRIPTION
Simple utility script to create a set of accounts in a batch.  This is really not ansible but useful tool after the cluster configuration is complete. It's really a bare minimum utility.  Anything more elaborate should probably go in a operations repo.